### PR TITLE
fix(Events): Quita el control de permiso admin en el search

### DIFF
--- a/apps/backend/src/app/events/event.controller.ts
+++ b/apps/backend/src/app/events/event.controller.ts
@@ -16,7 +16,7 @@ class EventsResource extends ResourceBase {
             return next();
 
         },
-        search: (req: Request, res: Response, next) => {
+        patch: (req: Request, res: Response, next) => {
             const permisoAdmin = checkPermission(req, 'admin:true');
             if (!permisoAdmin) {
                 return next(403);


### PR DESCRIPTION
- Quita el control  de permiso admin en el search, ya que un usuario no admin debe poder acceder a los eventos en los combos para registrar indicadores y en los filtros.
- Si se agrega en el patch para que no puedan editarlos.