### PR TITLE
OCURRENCE-EVENTS: limpieza de subfiltros al borrar el evento seleccionado

### DIFF
--- a/apps/frontend/src/app/ocurrence-events/components/ocurrence-events-list/ocurrence-events-list.component.ts
+++ b/apps/frontend/src/app/ocurrence-events/components/ocurrence-events-list/ocurrence-events-list.component.ts
@@ -91,6 +91,9 @@ export class OcurrenceEventsListComponent implements OnInit {
             ocurrenceEvents = ocurrenceEvents.filter(e => e.indicadores[subfiltro] === value.nombre);
           }
         });
+      } else {
+        this.subfiltros = [];
+        this.selectedSubfiltros = [];
       }
       from(ocurrenceEvents)
         .pipe(


### PR DESCRIPTION
Fix para que en el listado de eventos, al borrar el tipo de evento seleccionado se limpien los subfiltros y el subfiltro seleccionado.