### PR TITLE
EVENTOS: no permitir modificar el key a los eventos que tengan indicadores

### DIFF
--- a/apps/backend/src/app/ocurrence-events/ocurrence-events.controller.ts
+++ b/apps/backend/src/app/ocurrence-events/ocurrence-events.controller.ts
@@ -25,7 +25,7 @@ class OcurrenceEventResource extends ResourceBase {
     };
     searchFileds = {
         nombre: MongoQuery.partialString,
-        key: MongoQuery.partialString,
+        eventKey: MongoQuery.partialString,
         institucion: MongoQuery.equalMatch,
         instituciones: {
             field: 'institucion.id',

--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { OcurrenceEventsService } from './ocurrence-events/services/ocurrence-events.service';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
@@ -20,18 +21,18 @@ import { SelectSearchService } from './shared/select-search.service';
 import { AyudaComponent } from './home/ayuda.component';
 
 @NgModule({
-  declarations: [AppComponent, AppHomeComponent, AyudaComponent],
-  imports: [
-    BrowserModule,
-    PlexModule,
-    FormsModule,
-    HttpClientModule,
-    AppRouting,
-    NgxObserveModule,
-    InstitutionProvidersModule,
-    ChartModule
-  ],
-  providers: [Plex, Server, AuthService, RoutingNavBar, RoutingGuard, LocationService, SelectSearchService, UserService],
-  bootstrap: [AppComponent]
+    declarations: [AppComponent, AppHomeComponent, AyudaComponent],
+    imports: [
+        BrowserModule,
+        PlexModule,
+        FormsModule,
+        HttpClientModule,
+        AppRouting,
+        NgxObserveModule,
+        InstitutionProvidersModule,
+        ChartModule
+    ],
+    providers: [Plex, Server, AuthService, RoutingNavBar, RoutingGuard, LocationService, SelectSearchService, UserService, OcurrenceEventsService],
+    bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/apps/frontend/src/app/events/components/events-crud/events-crud.component.html
+++ b/apps/frontend/src/app/events/components/events-crud/events-crud.component.html
@@ -12,7 +12,7 @@
             <plex-wrapper>
                 <plex-text label="Nombre" [required]="true" name="nombre" [(ngModel)]="event.nombre"></plex-text>
                 <plex-text label="Categoría/Clave" required name="categoria" [(ngModel)]="event.categoria"
-                           [readonly]="event.id && event.indicadores.length > 0">
+                           [readonly]="hasOcurrences">
                 </plex-text>
                 <plex-bool label="Activo" type="slide" name="activo" [(ngModel)]="event.activo"></plex-bool>
             </plex-wrapper>

--- a/apps/frontend/src/app/events/components/events-crud/events-crud.component.html
+++ b/apps/frontend/src/app/events/components/events-crud/events-crud.component.html
@@ -11,7 +11,8 @@
             </plex-title>
             <plex-wrapper>
                 <plex-text label="Nombre" [required]="true" name="nombre" [(ngModel)]="event.nombre"></plex-text>
-                <plex-text label="Categoría/Clave" [required]="true" name="categoria" [(ngModel)]="event.categoria">
+                <plex-text label="Categoría/Clave" required name="categoria" [(ngModel)]="event.categoria"
+                           [readonly]="event.id && event.indicadores.length > 0">
                 </plex-text>
                 <plex-bool label="Activo" type="slide" name="activo" [(ngModel)]="event.activo"></plex-bool>
             </plex-wrapper>

--- a/apps/frontend/src/app/events/components/events-crud/events-crud.component.ts
+++ b/apps/frontend/src/app/events/components/events-crud/events-crud.component.ts
@@ -4,6 +4,7 @@ import { Plex } from '@andes/plex';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../../login/services/auth.services';
+import { OcurrenceEventsService } from '../../../ocurrence-events/services/ocurrence-events.service';
 
 @Component({
     selector: 'app-events-crud',
@@ -23,7 +24,7 @@ export class AppEventsCrudComponent implements OnInit {
         { id: 'localidad', nombre: 'Localidades' },
         { id: 'provincia', nombre: 'Provincias' },
     ];
-
+    public hasOcurrences = false;
     public event: Event = {
         id: '',
         categoria: '',
@@ -47,7 +48,8 @@ export class AppEventsCrudComponent implements OnInit {
         private location: Location,
         private route: ActivatedRoute,
         private auth: AuthService,
-        private router: Router
+        private router: Router,
+        private ocurrenceEventsService: OcurrenceEventsService
     ) { }
 
     ngOnInit() {
@@ -63,6 +65,9 @@ export class AppEventsCrudComponent implements OnInit {
                     indicador.recurso = this.selectList.find(t => t.id === indicador.recurso) as any;
                 }
             });
+            this.ocurrenceEventsService.search({ eventKey: event.categoria }).subscribe(response => {
+                this.hasOcurrences = response.length > 0;
+            })
         }
     }
 

--- a/apps/frontend/src/app/events/components/events-crud/events-crud.component.ts
+++ b/apps/frontend/src/app/events/components/events-crud/events-crud.component.ts
@@ -25,6 +25,7 @@ export class AppEventsCrudComponent implements OnInit {
     ];
 
     public event: Event = {
+        id: '',
         categoria: '',
         nombre: '',
         activo: true,

--- a/apps/frontend/src/app/events/service/events.service.ts
+++ b/apps/frontend/src/app/events/service/events.service.ts
@@ -2,6 +2,7 @@ import { ResourceBaseHttp, Server } from '@andes/shared';
 import { Injectable } from '@angular/core';
 
 export interface Event {
+    id: string,
     categoria: string;
     nombre: string;
     activo: boolean;


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/SAL-55

### Funcionalidad desarrollada 
1. Si el mismo tiene asociado indicadores, deberá deshabilitarse la edición de la key. Caso contrario se podrá cambiar.
