### PR TITLE
feat(dashboard): agrega dashboard de epidemiología

### DIFF
--- a/apps/backend/src/app/charts/charts.controller.ts
+++ b/apps/backend/src/app/charts/charts.controller.ts
@@ -3,6 +3,7 @@ import { Charts } from './charts.schema';
 import { authenticate } from '../application';
 const crypto = require('crypto');
 import { Request, Response } from '@andes/api-tool';
+import { environment } from '../../environments/environment';
 
 class ChartsResource extends ResourceBase {
     Model = Charts;
@@ -54,6 +55,31 @@ class ChartsResource extends ResourceBase {
         } catch (err) {
             next(err);
         }
+    }
+
+    public async getAPIToken() {
+        const url = `${environment.grafana.host}/api/auth/keys`;
+        const formData = new URLSearchParams();
+        formData.append('name', 'keysala');
+        formData.append('role', 'Viewer');
+        const options = {
+            method: 'POST',
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: formData.toString(),
+            json: true,
+        };
+        const response = await fetch(
+            url,
+            options
+        );
+        const responseJson = await response.json();
+        if (responseJson.key) {
+            return responseJson.key
+        }
+        return null;
+
     }
 }
 

--- a/apps/backend/src/environments/environment.ts
+++ b/apps/backend/src/environments/environment.ts
@@ -30,6 +30,11 @@ export const environment = {
         user: process.env.USER_SNVS || 'user',
         pass: process.env.PASS_SNVS || 'unapass'
     },
+    grafana: {
+        host: process.env.HOST_GRAFANA || 'http://localhost',
+        user: process.env.USER_GRAFANA || 'admin',
+        pass: process.env.PASS_GRAFANA || 'admin'
+    },
     exportadorHost: process.env.HOST_EXPORTADOR || ''
 };
 

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -47,9 +47,14 @@ export class AppComponent implements OnInit {
         if ((this.auth.checkPermisos('covid19:indicators:write')) || this.auth.checkPermisos('admin:true')) {
             this.accessList.push({ label: 'Dashboards', icon: 'chart-pie', route: '/chart/dashboard' });
         }
+        if ((this.auth.checkPermisos('covid19:indicators:write')) || this.auth.checkPermisos('admin:true')) {
+            this.accessList.push({ label: 'Epidemiologia', icon: 'trending-up', route: '/chart/epidemiologia' });
+        }
         if (this.auth.checkPermisos('admin:true')) {
             this.menuList.push({ label: 'Colaboradores', icon: 'account-circle', route: '/collaborator/list' });
         }
+
+
         this.accessList.forEach(element => {
             this.menuList.push(element);
         });

--- a/apps/frontend/src/app/charts/chart.module.ts
+++ b/apps/frontend/src/app/charts/chart.module.ts
@@ -5,6 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { PlexModule } from '@andes/plex';
 import { SafePipe } from './safe.pipe';
 import { AppChartComponent } from './components/chart.component';
+import { EpidemiologiaComponent } from './components/epidemiologia.component';
 import { ChartRouting } from './chart.routing';
 import { ChartsService } from './service/charts.service';
 @NgModule({
@@ -16,10 +17,12 @@ import { ChartsService } from './service/charts.service';
         ChartRouting
     ],
     exports: [
-        AppChartComponent
+        AppChartComponent,
+        EpidemiologiaComponent
     ],
     declarations: [
         AppChartComponent,
+        EpidemiologiaComponent,
         SafePipe,
     ],
     providers: [

--- a/apps/frontend/src/app/charts/chart.routing.ts
+++ b/apps/frontend/src/app/charts/chart.routing.ts
@@ -1,9 +1,11 @@
 import { Routes, RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { AppChartComponent } from './components/chart.component';
+import { EpidemiologiaComponent } from './components/epidemiologia.component';
 
 const routes: Routes = [
     { path: 'dashboard', component: AppChartComponent },
+    { path: 'epidemiologia', component: EpidemiologiaComponent }
 ];
 
 @NgModule({

--- a/apps/frontend/src/app/charts/components/epidemiologia.component.html
+++ b/apps/frontend/src/app/charts/components/epidemiologia.component.html
@@ -1,0 +1,5 @@
+<plex-layout>
+    <plex-layout-main>
+        <iframe [src]="url | safe" width="100%" height="100%"></iframe>
+    </plex-layout-main>
+</plex-layout>

--- a/apps/frontend/src/app/charts/components/epidemiologia.component.ts
+++ b/apps/frontend/src/app/charts/components/epidemiologia.component.ts
@@ -1,0 +1,19 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { environment } from 'apps/frontend/src/environments/environment';
+
+@Component({
+    selector: 'epidemiologia',
+    templateUrl: './epidemiologia.component.html'
+})
+
+export class EpidemiologiaComponent implements AfterViewInit {
+    public url;
+    dashboard: string;
+
+    ngAfterViewInit(): void {
+        this.dashboard = 'd/55L74SeZz/sala-de-situacion-coronavirus-neuquen?orgId=1';
+        this.url = `${environment.GRAFANA}${this.dashboard}`;
+
+    }
+
+}

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   API: '/api',
-  charts_embedding_base_url: 'http://localhost/mongodb-charts-zypoq'
+  GRAFANA: '/grafana'
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -5,6 +5,7 @@
 export const environment = {
   production: false,
   API: '//localhost:3000/api',
+  GRAFANA: '//localhost/'
 };
 
 /*


### PR DESCRIPTION
 - Agrega dashboard de epidemiología con datos de coronavirus

Cambios requeridos
1. Configurar un grafana-proxy 
 docker run -itd --name grafana-proxy --rm -p 80:80 \
  --env GRAFANA_PROXY_USE_HTTPS=false \
  --env GRAFANA_BASE_URL=http://localhost:3000 \
  --env GRAFANA_API_KEY=key \
  --env GRAFANA_INJECT_CUSTOM_CSS=true \
cashee/grafana-proxy:latest


